### PR TITLE
Fixing import & using python3

### DIFF
--- a/anytime.py
+++ b/anytime.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3.6
+#!/usr/local/bin/python3
 from things import *
 import xml.etree.ElementTree
 

--- a/inbox.py
+++ b/inbox.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3.6
+#!/usr/local/bin/python3
 from things import *
 
 for task in Things.inbox():

--- a/logbook.py
+++ b/logbook.py
@@ -1,5 +1,5 @@
-#!/usr/local/bin/python3.6
 from things_object import *
+#!/usr/local/bin/python3
 
 last = None
 for item in Things.logbook():

--- a/logbook.py
+++ b/logbook.py
@@ -1,5 +1,5 @@
-from things_object import *
 #!/usr/local/bin/python3
+from things import *
 
 last = None
 for item in Things.logbook():

--- a/query.py
+++ b/query.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3.6
+#!/usr/local/bin/python3
 from things import *
 
 # Configuration

--- a/someday.py
+++ b/someday.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3.6
+#!/usr/local/bin/python3
 from things import *
 
 # Configuration

--- a/today.py
+++ b/today.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3.6
+#!/usr/local/bin/python3
 from things import *
 
 last = None

--- a/upcoming.py
+++ b/upcoming.py
@@ -1,5 +1,5 @@
-from things_object import *
 #!/usr/local/bin/python3
+from things import *
 
 query = Things.upcoming()
 #print(Things.expand_sql(query.sql()))

--- a/upcoming.py
+++ b/upcoming.py
@@ -1,5 +1,5 @@
-#!/usr/local/bin/python3.6
 from things_object import *
+#!/usr/local/bin/python3
 
 query = Things.upcoming()
 #print(Things.expand_sql(query.sql()))


### PR DESCRIPTION
Not sure if this is ok, but I changed the python reference to `python3`. I have python 3.7 locally installed and that allows it to work with it rather than having to preface any call with `python3.7` or `python3`. 

I also noticed a couple incorrect imports in `logbook.py` and `upcoming.py`.

I'm a python n00b, so feel free to decline this. 😄 